### PR TITLE
Fix OAuth authentication by passing instance_url to AuthManager

### DIFF
--- a/src/servicenow_mcp/server.py
+++ b/src/servicenow_mcp/server.py
@@ -95,7 +95,7 @@ class ServiceNowMCP:
         else:
             self.config = config
 
-        self.auth_manager = AuthManager(self.config.auth)
+        self.auth_manager = AuthManager(self.config.auth, self.config.instance_url)
         self.mcp_server = Server("ServiceNow")  # Use low-level Server
         self.name = "ServiceNow"
 


### PR DESCRIPTION
## OAuth Authentication Fix Summary

**Problem**: OAuth authentication was failing because `AuthManager._get_oauth_token()` was trying to access `oauth_config.instance_url`, but the `OAuthConfig` class only has a `token_url` field, not an `instance_url` field.

**Solution**: Pass the instance URL separately to the `AuthManager` constructor from the main server configuration.

**Required Changes**:

1. **`src/servicenow_mcp/auth/auth_manager.py`**:
   - Add `instance_url: str = None` parameter to `__init__()` 
   - Store as `self.instance_url = instance_url`
   - In `_get_oauth_token()`, replace `oauth_config.instance_url` with `self.instance_url`
   - Add proper error handling if `instance_url` is None

2. **`src/servicenow_mcp/server.py`**:
   - Update AuthManager instantiation from:
     ```python
     self.auth_manager = AuthManager(self.config.auth)
     ```
   - To:
     ```python
     self.auth_manager = AuthManager(self.config.auth, self.config.instance_url)
     ```

3. **Enhanced OAuth flow** (optional but recommended):
   - Implement both `client_credentials` and `password` grant types
   - Use proper Basic Auth headers for OAuth token requests
   - Add detailed logging for debugging OAuth issues

This allows the AuthManager to access the instance URL needed for constructing the OAuth token endpoint URL when `token_url` is not explicitly configured.