### PR TITLE
[FEAT] Allow the MCP server to be deployed to Google Cloud Run

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,73 @@
+# This file specifies files that are *not* uploaded to Google Cloud
+# using gcloud. It follows the same syntax as .gitignore, with the addition of
+# "#!include" directives (which insert the entries of the given .gitignore-style
+# file at that point).
+#
+# For more information, run:
+#   $ gcloud topic gcloudignore
+#
+.gcloudignore
+# If you would like to upload your .git directory, .gitignore file or files
+# from your .gitignore file, remove the corresponding line
+# below:
+.git
+.gitignore
+
+# Python pycache:
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+.tox/
+.nox/
+coverage.xml
+*.cover
+*.log
+
+# Documentation
+docs/
+*.md
+!README.md
+
+# Development
+.mypy_cache/
+.dmypy.json
+dmypy.json
+.ruff_cache/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Project specific
+examples/
+tests/
+scripts/
+prompts/
+uv.lock
+.cursorrules
+
+# Deployment scripts (we don't want to upload these)
+deploy.sh
+deploy-with-secrets.sh
+cloudrun-service.yaml

--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -1,0 +1,115 @@
+# ServiceNow MCP - Google Cloud Run Deployment Guide
+
+Deploy the ServiceNow MCP server to Google Cloud Run without Docker installed locally.
+
+## Prerequisites
+
+1. **Google Cloud SDK (gcloud)** installed and authenticated
+2. **Google Cloud Project** with billing enabled
+3. **ServiceNow credentials** in your `.env` file
+
+## Quick Start
+
+```bash
+./deploy-with-secrets.sh
+```
+
+This script:
+- Loads credentials from `.env`
+- Stores passwords in Google Secret Manager
+- Builds container using Cloud Build
+- Deploys to Cloud Run with enhanced security
+- Displays the service URL
+
+## Manual Deployment
+
+### Direct from source:
+```bash
+gcloud run deploy servicenow-mcp \
+  --source . \
+  --platform managed \
+  --region us-central1 \
+  --allow-unauthenticated \
+  --port 8080 \
+  --set-env-vars-file .env
+```
+
+### Using Cloud Build:
+```bash
+# Build image
+gcloud builds submit --tag gcr.io/YOUR_PROJECT_ID/servicenow-mcp
+
+# Deploy image
+gcloud run deploy servicenow-mcp \
+  --image gcr.io/YOUR_PROJECT_ID/servicenow-mcp \
+  --platform managed \
+  --region us-central1 \
+  --allow-unauthenticated \
+  --port 8080 \
+  --set-env-vars-file .env
+```
+
+## Environment Variables
+
+| Variable | Description | Required |
+|----------|-------------|----------|
+| `SERVICENOW_INSTANCE_URL` | ServiceNow instance URL | Yes |
+| `SERVICENOW_USERNAME` | ServiceNow username | Yes |
+| `SERVICENOW_PASSWORD` | ServiceNow password | Yes |
+| `SERVICENOW_AUTH_TYPE` | Auth type (basic/oauth/api_key) | No |
+| `MCP_TOOL_PACKAGE` | Tool package (full/minimal/none) | No |
+
+## Service Endpoints
+
+- **SSE Endpoint**: `https://[service-url]/sse` - For MCP clients
+- **Health Check**: `https://[service-url]/health` - Service status
+- **Messages**: `https://[service-url]/messages/` - MCP messages
+
+## Connecting with MCP Inspector
+
+1. Deploy the service using one of the methods above
+2. Copy the service URL from the deployment output
+3. Open MCP Inspector
+4. Enter: `https://[service-url]/sse`
+5. Click Connect
+
+## Troubleshooting
+
+### View logs:
+```bash
+gcloud run services logs read servicenow-mcp --region us-central1
+```
+
+### Stream logs:
+```bash
+gcloud run services logs tail servicenow-mcp --region us-central1
+```
+
+### Common issues:
+- **"gcloud not found"**: Install [Google Cloud SDK](https://cloud.google.com/sdk/docs/install)
+- **"Project not set"**: Run `gcloud config set project YOUR_PROJECT_ID`
+- **Build failures**: Check logs with `gcloud builds list --limit=5`
+
+## Updating the Service
+
+```bash
+# Using deployment script
+./deploy-with-secrets.sh
+
+# Or manually
+gcloud run deploy servicenow-mcp --source . --region us-central1
+```
+
+## Cleanup
+
+```bash
+# Delete service
+gcloud run services delete servicenow-mcp --region us-central1
+
+# Delete secrets (if using secure deployment)
+gcloud secrets delete servicenow-password
+```
+
+## Cost Optimization
+
+Cloud Run charges only when handling requests and scales to zero when idle. First 2 million requests per month are free.

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /app
 # Copy project files
 COPY pyproject.toml README.md LICENSE ./
 COPY src/ ./src/
+COPY config/ ./config/
 
 # Install the package in development mode
 RUN pip install -e .

--- a/deploy-with-secrets.sh
+++ b/deploy-with-secrets.sh
@@ -1,0 +1,227 @@
+#!/bin/bash
+
+# ServiceNow MCP - Google Cloud Run Deployment Script with Secret Manager
+# This script deploys the ServiceNow MCP server to Google Cloud Run using Google Secret Manager for sensitive data
+
+set -e
+
+# Color codes for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Default values
+PROJECT_ID=""
+REGION="us-central1"
+SERVICE_NAME="servicenow-mcp"
+
+# Function to print colored output
+print_info() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Function to check if gcloud is installed
+check_gcloud() {
+    if ! command -v gcloud &> /dev/null; then
+        print_error "gcloud CLI is not installed. Please install it from: https://cloud.google.com/sdk/docs/install"
+        exit 1
+    fi
+}
+
+# Function to get current project
+get_current_project() {
+    local current_project=$(gcloud config get-value project 2>/dev/null)
+    if [ -n "$current_project" ]; then
+        PROJECT_ID=$current_project
+    fi
+}
+
+# Function to check if .env file exists
+check_env_file() {
+    if [ ! -f ".env" ]; then
+        print_error ".env file not found. Please create it with your ServiceNow credentials."
+        exit 1
+    fi
+}
+
+# Function to read environment variables from .env file
+load_env_vars() {
+    print_info "Loading environment variables from .env file..."
+    
+    # Read .env file and export variables
+    while IFS='=' read -r key value; do
+        # Skip comments and empty lines
+        if [[ ! "$key" =~ ^#.*$ ]] && [[ -n "$key" ]]; then
+            # Remove quotes from value
+            value="${value%\"}"
+            value="${value#\"}"
+            export "$key=$value"
+        fi
+    done < .env
+}
+
+# Function to create or update a secret
+create_or_update_secret() {
+    local secret_name=$1
+    local secret_value=$2
+    
+    # Check if secret exists
+    if gcloud secrets describe $secret_name --project=$PROJECT_ID &>/dev/null; then
+        print_info "Updating existing secret: $secret_name"
+        echo -n "$secret_value" | gcloud secrets versions add $secret_name --data-file=- --project=$PROJECT_ID
+    else
+        print_info "Creating new secret: $secret_name"
+        echo -n "$secret_value" | gcloud secrets create $secret_name --data-file=- --project=$PROJECT_ID
+    fi
+}
+
+# Function to grant Cloud Run access to secrets
+grant_secret_access() {
+    local secret_name=$1
+    local service_account=$2
+    
+    print_info "Granting access to secret: $secret_name"
+    gcloud secrets add-iam-policy-binding $secret_name \
+        --member="serviceAccount:$service_account" \
+        --role="roles/secretmanager.secretAccessor" \
+        --project=$PROJECT_ID
+}
+
+# Main deployment function
+deploy_to_cloud_run() {
+    print_info "Starting deployment to Google Cloud Run with Secret Manager..."
+    
+    # Check prerequisites
+    check_gcloud
+    check_env_file
+    load_env_vars
+    
+    # Get current project if not set
+    if [ -z "$PROJECT_ID" ]; then
+        get_current_project
+        if [ -z "$PROJECT_ID" ]; then
+            print_error "No Google Cloud project set. Please run: gcloud config set project YOUR_PROJECT_ID"
+            exit 1
+        fi
+    fi
+    
+    print_info "Using project: $PROJECT_ID"
+    print_info "Deploying to region: $REGION"
+    print_info "Service name: $SERVICE_NAME"
+    
+    # Enable required APIs
+    print_info "Enabling required Google Cloud APIs..."
+    gcloud services enable secretmanager.googleapis.com --project=$PROJECT_ID
+    gcloud services enable cloudbuild.googleapis.com --project=$PROJECT_ID
+    gcloud services enable run.googleapis.com --project=$PROJECT_ID
+    
+    # Get the Cloud Run service account
+    PROJECT_NUMBER=$(gcloud projects describe $PROJECT_ID --format='value(projectNumber)')
+    SERVICE_ACCOUNT="${PROJECT_NUMBER}-compute@developer.gserviceaccount.com"
+    
+    # Create secrets
+    print_info "Creating/updating secrets in Secret Manager..."
+    create_or_update_secret "servicenow-password" "$SERVICENOW_PASSWORD"
+    
+    # Grant access to secrets
+    grant_secret_access "servicenow-password" "$SERVICE_ACCOUNT"
+    
+    # Confirm deployment
+    echo ""
+    print_warning "This will deploy the ServiceNow MCP server with the following configuration:"
+    echo "  - Instance URL: $SERVICENOW_INSTANCE_URL"
+    echo "  - Username: $SERVICENOW_USERNAME"
+    echo "  - Password: [STORED IN SECRET MANAGER]"
+    echo ""
+    read -p "Do you want to continue? (y/N) " -n 1 -r
+    echo ""
+    
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        print_info "Deployment cancelled."
+        exit 0
+    fi
+    
+    # Deploy to Cloud Run
+    print_info "Deploying to Cloud Run (this may take a few minutes)..."
+    
+    gcloud run deploy $SERVICE_NAME \
+        --source . \
+        --platform managed \
+        --region $REGION \
+        --allow-unauthenticated \
+        --port 8080 \
+        --set-env-vars SERVICENOW_INSTANCE_URL="$SERVICENOW_INSTANCE_URL" \
+        --set-env-vars SERVICENOW_USERNAME="$SERVICENOW_USERNAME" \
+        --set-env-vars SERVICENOW_AUTH_TYPE="basic" \
+        --set-env-vars MCP_TOOL_PACKAGE="full" \
+        --update-secrets SERVICENOW_PASSWORD=servicenow-password:latest \
+        --timeout 300 \
+        --max-instances 10 \
+        --project=$PROJECT_ID
+    
+    if [ $? -eq 0 ]; then
+        print_info "Deployment successful!"
+        
+        # Get the service URL
+        SERVICE_URL=$(gcloud run services describe $SERVICE_NAME --region $REGION --format 'value(status.url)' --project=$PROJECT_ID)
+        
+        echo ""
+        print_info "Your ServiceNow MCP server is now running at:"
+        echo "  $SERVICE_URL"
+        echo ""
+        print_info "SSE endpoint: $SERVICE_URL/sse"
+        print_info "Messages endpoint: $SERVICE_URL/messages/"
+        echo ""
+        print_info "Secrets are stored in Google Secret Manager for enhanced security."
+    else
+        print_error "Deployment failed. Please check the error messages above."
+        exit 1
+    fi
+}
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --project)
+            PROJECT_ID="$2"
+            shift 2
+            ;;
+        --region)
+            REGION="$2"
+            shift 2
+            ;;
+        --service-name)
+            SERVICE_NAME="$2"
+            shift 2
+            ;;
+        --help)
+            echo "Usage: $0 [OPTIONS]"
+            echo ""
+            echo "Options:"
+            echo "  --project PROJECT_ID      Google Cloud project ID"
+            echo "  --region REGION          Deployment region (default: us-central1)"
+            echo "  --service-name NAME      Cloud Run service name (default: servicenow-mcp)"
+            echo "  --help                   Show this help message"
+            echo ""
+            echo "This script uses Google Secret Manager to securely store sensitive credentials."
+            exit 0
+            ;;
+        *)
+            print_error "Unknown option: $1"
+            echo "Use --help for usage information"
+            exit 1
+            ;;
+    esac
+done
+
+# Run the deployment
+deploy_to_cloud_run

--- a/src/servicenow_mcp/server_sse.py
+++ b/src/servicenow_mcp/server_sse.py
@@ -15,6 +15,7 @@ from mcp.server.fastmcp import FastMCP
 from mcp.server.sse import SseServerTransport
 from starlette.applications import Starlette
 from starlette.requests import Request
+from starlette.responses import PlainTextResponse
 from starlette.routing import Mount, Route
 
 from servicenow_mcp.server import ServiceNowMCP
@@ -37,9 +38,13 @@ def create_starlette_app(mcp_server: Server, *, debug: bool = False) -> Starlett
                 mcp_server.create_initialization_options(),
             )
 
+    async def health_check(request: Request) -> PlainTextResponse:
+        return PlainTextResponse("OK", status_code=200)
+
     return Starlette(
         debug=debug,
         routes=[
+            Route("/health", endpoint=health_check),
             Route("/sse", endpoint=handle_sse),
             Mount("/messages/", app=sse.handle_post_message),
         ],

--- a/src/servicenow_mcp/utils/tool_utils.py
+++ b/src/servicenow_mcp/utils/tool_utils.py
@@ -119,6 +119,7 @@ from servicenow_mcp.tools.changeset_tools import (
 from servicenow_mcp.tools.incident_tools import (
     AddCommentParams,
     CreateIncidentParams,
+    GetIncidentByNumberParams,
     ListIncidentsParams,
     ResolveIncidentParams,
     UpdateIncidentParams,
@@ -128,6 +129,9 @@ from servicenow_mcp.tools.incident_tools import (
 )
 from servicenow_mcp.tools.incident_tools import (
     create_incident as create_incident_tool,
+)
+from servicenow_mcp.tools.incident_tools import (
+    get_incident_by_number as get_incident_by_number_tool,
 )
 from servicenow_mcp.tools.incident_tools import (
     list_incidents as list_incidents_tool,
@@ -395,6 +399,13 @@ def get_tool_definitions(
             str,  # Expects JSON string
             "List incidents from ServiceNow",
             "json",  # Tool returns list/dict, needs JSON dump
+        ),
+        "get_incident_by_number": (
+            get_incident_by_number_tool,
+            GetIncidentByNumberParams,
+            str,  # Expects JSON string
+            "Fetch a single incident from ServiceNow by its number",
+            "json",  # Tool returns dict
         ),
         # Catalog Tools
         "list_catalog_items": (


### PR DESCRIPTION
__Changes (2 files modified):__

1. __Dockerfile__ - Added `COPY config/ ./config/` to include tool packages configuration
2. __src/servicenow_mcp/server_sse.py__ - Added `/health` endpoint for Cloud Run health checks
3. __src/servicenow_mcp/utils/tool_utils.py__ - Exposed `get_incident_by_number` from the MCP server

__New Files Added (3 files):__

1. __DEPLOYMENT_GUIDE.md__ - Comprehensive deployment documentation
2. __deploy-with-secrets.sh__ - Production-ready deployment script with Secret Manager
4. __.gcloudignore__ - Prevents unnecessary files from being uploaded to Cloud Build
