### PR TITLE
feat: Add get_incident_by_number tool (#1)

### DIFF
--- a/src/servicenow_mcp/utils/tool_utils.py
+++ b/src/servicenow_mcp/utils/tool_utils.py
@@ -119,6 +119,7 @@ from servicenow_mcp.tools.changeset_tools import (
 from servicenow_mcp.tools.incident_tools import (
     AddCommentParams,
     CreateIncidentParams,
+    GetIncidentByNumberParams,
     ListIncidentsParams,
     ResolveIncidentParams,
     UpdateIncidentParams,
@@ -128,6 +129,9 @@ from servicenow_mcp.tools.incident_tools import (
 )
 from servicenow_mcp.tools.incident_tools import (
     create_incident as create_incident_tool,
+)
+from servicenow_mcp.tools.incident_tools import (
+    get_incident_by_number as get_incident_by_number_tool,
 )
 from servicenow_mcp.tools.incident_tools import (
     list_incidents as list_incidents_tool,
@@ -395,6 +399,13 @@ def get_tool_definitions(
             str,  # Expects JSON string
             "List incidents from ServiceNow",
             "json",  # Tool returns list/dict, needs JSON dump
+        ),
+        "get_incident_by_number": (
+            get_incident_by_number_tool,
+            GetIncidentByNumberParams,
+            str,  # Expects JSON string
+            "Get a specific incident from ServiceNow by its number",
+            "json",  # Tool returns dict, needs JSON dump
         ),
         # Catalog Tools
         "list_catalog_items": (


### PR DESCRIPTION
This commit adds the `get_incident_by_number` tool to the MCP server.

The tool was already implemented in `src/servicenow_mcp/tools/incident_tools.py`, but it was not registered in the tool discovery mechanism in `src/servicenow_mcp/utils/tool_utils.py`.

This commit adds the necessary imports and registration for the tool to be available to the server.

Note: The test suite is in a broken state. I have run the tests relevant to my changes (`tests/test_incident_tools.py`) and they are passing. I have ignored other failing tests as they appear to be unrelated to my changes and fixing them is outside the scope of this task.